### PR TITLE
Adds feature for listing secrets of a file

### DIFF
--- a/.semver
+++ b/.semver
@@ -1,5 +1,5 @@
 ---
 :major: 0
-:minor: 3
+:minor: 4
 :patch: 0
 :special: ''

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [0.4.0] - 2020-09-15
+ - Adds feature for getting the whole file instead of a single key the encrypted json

--- a/README.md
+++ b/README.md
@@ -66,6 +66,27 @@ If everything goes right, you'll get the following output:
 [SUCCESS] Secret my_secret_key content is SUPER_SECRET_CONTENT
 ```
 
+## Usage to get the whole secrets file decrypted
+
+```bash
+$ docker build -t victoria_treasure .
+# Edit the secrets.env file to add the necessary variables
+$ docker run --env-file=secrets.env victoria_treasure victoria-playground-secrets/apps/testing-secrets/app
+```
+
+Where:
+
+* `victoria-playground-secrets/apps/testing-secrets/app`: is the route where the secret file is stored and you want to check, if you put a file that not exists in the s3, the result will be empty
+
+
+If everything goes right, you'll get the following output:
+
+```text
+[SUCCESS] Secret content is {
+  "secre_key": "secret_value"
+}
+```
+
 ## Running the tests
 
 ```bash

--- a/lib/s3secrets/reader.rb
+++ b/lib/s3secrets/reader.rb
@@ -1,5 +1,6 @@
 require 's3secrets/helpers/s3'
 require 's3secrets/helpers/kms'
+require 'json'
 
 module S3Secrets
   class Reader
@@ -8,12 +9,15 @@ module S3Secrets
       @s3_helper = S3Secrets::Helpers::S3.new(s3_client, s3_resource)
     end
 
-    def get_secret(file_uri, key)
+    def get_secret(file_uri, key = '')
       object = File.extname(file_uri).empty? ? "#{file_uri}.json.encrypted" : file_uri
       bucket = @s3_helper.bucket_from_file_uri(object)
       file_path = @s3_helper.file_path_from_file_uri(object)
 
       decrypted_json = get_json_secret_content(bucket, file_path)
+
+      return JSON.pretty_generate(decrypted_json) if key == '' || key.nil?
+
       decrypted_json[key]
     end
 

--- a/s3secrets.rb
+++ b/s3secrets.rb
@@ -36,7 +36,7 @@ def is_update?
 end
 
 def is_read?
-  ARGV.length == 2
+  ARGV.length <= 2
 end
 
 def perform_update

--- a/spec/reader_spec.rb
+++ b/spec/reader_spec.rb
@@ -38,5 +38,42 @@ RSpec.describe S3Secrets::Reader do
 
       reader.get_secret(file_path, "my_secret") == json_content[:my_secret]
     end
+
+    it 'gets the whole file from s3 if no json key is specified' do
+      kms_key_id = 'kmsid'
+      stubbed_s3_client = stub_s3_client
+      stubbed_kms_client = stub_kms_client
+
+      reader = S3Secrets::Reader.new(
+        stub_s3_resource,
+        stubbed_s3_client,
+        stubbed_kms_client,
+        kms_key_id
+      )
+
+      file_path = 'mys3/uploads/file'
+      bucket = 'mys3'
+      file_key = 'uploads/file.json.encrypted'
+      json_content = { my_secret: 'this_is_my_secret_peeeim' }
+
+      expected_get_object_args = {
+        bucket: bucket,
+        key: file_key
+      }
+
+      expected_decrypt_args = {
+        ciphertext_blob: json_content.to_json
+      }
+
+      expect(stubbed_s3_client).to receive(:get_object)
+        .with(expected_get_object_args)
+        .and_call_original
+
+      expect(stubbed_kms_client).to receive(:decrypt)
+        .with(expected_decrypt_args)
+        .and_call_original
+
+      reader.get_secret(file_path) == json_content
+    end
   end
 end


### PR DESCRIPTION
Added feature for getting the whole secret file instead of a single key.

```
▶ docker run --rm --env-file=secrets.env victoria_treasure bucket/apps/service-a/secret
[SUCCESS] Secret  content is {
  "key": "value"
}
```