### PR TITLE
[SREFTP-3162] Force KMS ID command output to json

### DIFF
--- a/get_aws_secrets.sh
+++ b/get_aws_secrets.sh
@@ -27,7 +27,7 @@ case "$secret_location" in
    ;;
 esac
 
-KMS_KEY_ID=`aws-okta exec $aws_account_profile -- aws kms list-aliases | grep -h1 $ACCOUNT_ALIAS\" | grep TargetKeyId | awk -F '\"' '{print $4}'`
+KMS_KEY_ID=`aws-okta exec $aws_account_profile -- aws kms list-aliases --output json| grep -h1 $ACCOUNT_ALIAS\" | grep TargetKeyId | awk -F '\"' '{print $4}'`
 echo KMS_KEY_ID=$KMS_KEY_ID >> secrets.env
 
 echo "Credentials correctly set, now you are able to create secrets"

--- a/get_aws_secrets.sh
+++ b/get_aws_secrets.sh
@@ -9,25 +9,26 @@ echo "Where are you going to create the secret? b, branch | s, staging | p, prod
 
 read secret_location
 case "$secret_location" in
-   b|branch)
-     ACCOUNT_ALIAS=victoria-playground
-   ;;
-   s|staging)
-     ACCOUNT_ALIAS=victoria-staging
-   ;;
-   p|production)
-     ACCOUNT_ALIAS=victoria-production
-   ;;
-   d|detect)
+  b|branch)
+    ACCOUNT_ALIAS=victoria-playground
+  ;;
+  s|staging)
+    ACCOUNT_ALIAS=victoria-staging
+  ;;
+  p|production)
+    ACCOUNT_ALIAS=victoria-production
+  ;;
+  d|detect)
     ACCOUNT_ALIAS=`aws-okta exec $aws_account_profile -- aws iam list-account-aliases --query 'AccountAliases[0]' --output text`
-   ;;
+  ;;
    *)
       echo "Invalid answer, please choose between: b, branch | s, staging | p, production | d, detect"
       exit 1
-   ;;
+  ;;
 esac
 
-KMS_KEY_ID=`aws-okta exec $aws_account_profile -- aws kms list-aliases --output json| grep -h1 $ACCOUNT_ALIAS\" | grep TargetKeyId | awk -F '\"' '{print $4}'`
+KMS_KEY_ID=`aws-okta exec $aws_account_profile -- aws kms list-aliases  --output json | jq -r --arg ACCOUNT_ALIAS $ACCOUNT_ALIAS '.Aliases[] | select(.AliasName|endswith($ACCOUNT_ALIAS)) | .TargetKeyId'`
+
 echo KMS_KEY_ID=$KMS_KEY_ID >> secrets.env
 
 echo "Credentials correctly set, now you are able to create secrets"


### PR DESCRIPTION
Changed the output on the command to get the KMS key ID so it forces it to be json and executes ok even if by default the user has yaml as output configured for AWS cli.