### PR TITLE
[SREFTP-3301] Check if jq is installed

### DIFF
--- a/.semver
+++ b/.semver
@@ -1,5 +1,5 @@
 ---
 :major: 0
 :minor: 4
-:patch: 3
+:patch: 4
 :special: ''

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.4.4] - 2021-07-30
+ - Add check jq is installed 
+
 ## [0.4.3] - 2021-06-4
  - Fixes output when getting KMS keys
  - README.md now contains jq dependency

--- a/get_aws_secrets.sh
+++ b/get_aws_secrets.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 [ -z `which aws-okta` ] && echo "Please run 'brew install aws-okta' in order to operate this script" && exit 1
+[ -z `which jq` ] && echo "Please run 'brew install jq' in order to operate this script" && exit 1
 
 aws_account_profile=$1
 


### PR DESCRIPTION
If `jq` is not installed the error is not helpful:

```
validation error detected: Value '' at 'keyId' failed to satisfy constraint: Member must have length greater than or equal to 1 (Aws::KMS::Errors::ValidationException)
```