### PR TITLE
fix: adds credentials action for allowing git operations in the repo

### DIFF
--- a/.github/workflows/release_artifact.yml
+++ b/.github/workflows/release_artifact.yml
@@ -19,6 +19,10 @@ jobs:
     - name: Docker linting
       run: docker run --rm -i hadolint/hadolint < Dockerfile
 
+    - uses: oleksiyrudenko/gha-git-credentials@v2-latest
+      with:
+        token: '${{ secrets.GITHUB_TOKEN }}'
+
     - name: Unit testing
       run: |
         mv .dockerignore deploy

--- a/.semver
+++ b/.semver
@@ -1,5 +1,5 @@
 ---
 :major: 0
 :minor: 4
-:patch: 4
+:patch: 5
 :special: ''

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.4.5] - 2021-11-30
+
+### Fixes
+ - Adds credentiasl action for allowing git operations in the repo
+   - This will fix the problem we have now for creating git tags 
+
 ## [0.4.4] - 2021-07-30
  - Add check jq is installed 
 


### PR DESCRIPTION
This is for fixing the problem we have now for pushing git tags