### PR TITLE
ci: change base os from ubuntu-18 to ubuntu-20

### DIFF
--- a/.github/workflows/test_branch.yml
+++ b/.github/workflows/test_branch.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Docker linting


### PR DESCRIPTION
The ubuntu-18 base os is deprecated according to the [github action docs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idruns-on)

Tags: Hacktoberfest