### PR TITLE
build: remove dockeignore hack

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
 Dockerfile
 vendor/
 .git/
-spec/

--- a/.github/workflows/release_artifact.yml
+++ b/.github/workflows/release_artifact.yml
@@ -25,9 +25,7 @@ jobs:
 
     - name: Unit testing
       run: |
-        mv .dockerignore deploy
-        docker build -t $CONTAINER_TEST_IMAGE .
-        mv deploy/.dockerignore .
+        docker build -t $CONTAINER_TEST_IMAGE --target=test .
         docker run --entrypoint="" $CONTAINER_TEST_IMAGE rake test
 
     - name: Retrieve version
@@ -36,7 +34,7 @@ jobs:
     - name: Build release image
       run: |
         VERSION=$(cat $VERSION_FILE)
-        docker build -t $CONTAINER_RELEASE_IMAGE:$VERSION .
+        docker build -t $CONTAINER_RELEASE_IMAGE:$VERSION --target=release .
         docker tag $CONTAINER_RELEASE_IMAGE:$VERSION $CONTAINER_RELEASE_IMAGE:latest
 
     - name: Push git tag

--- a/.github/workflows/test_branch.yml
+++ b/.github/workflows/test_branch.yml
@@ -19,7 +19,5 @@ jobs:
 
     - name: Unit testing
       run: |
-        mv .dockerignore deploy
-        docker build -t $CONTAINER_TEST_IMAGE .
-        mv deploy/.dockerignore .
+        docker build -t $CONTAINER_TEST_IMAGE --target=test .
         docker run --entrypoint="" $CONTAINER_TEST_IMAGE rake test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,19 @@
-FROM gcr.io/registry-public/ruby:v2-stable
+FROM gcr.io/registry-public/ruby:v2-stable as base
 
 ENV CONTAINER_ROOT /app
 RUN mkdir -p $CONTAINER_ROOT
 WORKDIR $CONTAINER_ROOT
 
+FROM base as test
 COPY Gemfile Gemfile.lock $CONTAINER_ROOT/
-
 RUN bundle install
-
 COPY . $CONTAINER_ROOT/
+CMD ["ruby", "s3secrets.rb"]
 
-ENTRYPOINT ["ruby", "s3secrets.rb"]
+FROM base as release
+COPY Gemfile Gemfile.lock $CONTAINER_ROOT/
+RUN bundle install --without=test
+COPY lib $CONTAINER_ROOT/lib
+COPY s3secrets.rb Rakefile LICENSE $CONTAINER_ROOT/
+
+CMD ["ruby", "s3secrets.rb"]


### PR DESCRIPTION
There was a hack in place to copy the spec files into the container, however, this can be fixed more elegantly by using multistage build in docker.

Flags: Hacktoberfest