### PR TITLE
fix(Dockerfile): Add ENTRYPOINT instead of CMD

### DIFF
--- a/.semver
+++ b/.semver
@@ -1,5 +1,5 @@
 ---
 :major: 0
 :minor: 5
-:patch: 0 
+:patch: 1 
 :special: ''

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2022-11-02
+ - Restore ENTRYPOINT in Dockerfile instead of CMD
+
 ## [0.5.0] - 2022-08-17
  - Remove aws-okta dependency
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ FROM base as test
 COPY Gemfile Gemfile.lock $CONTAINER_ROOT/
 RUN bundle install
 COPY . $CONTAINER_ROOT/
-CMD ["ruby", "s3secrets.rb"]
+ENTRYPOINT ["ruby", "s3secrets.rb"]
 
 FROM base as release
 COPY Gemfile Gemfile.lock $CONTAINER_ROOT/
@@ -16,4 +16,4 @@ RUN bundle install --without=test
 COPY lib $CONTAINER_ROOT/lib
 COPY s3secrets.rb Rakefile LICENSE $CONTAINER_ROOT/
 
-CMD ["ruby", "s3secrets.rb"]
+ENTRYPOINT ["ruby", "s3secrets.rb"]

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ docker build -t victoria_treasure --target=test .
 ## Running the tests
 
 ```bash
-docker run victoria_treasure rake test
+docker run --entrypoint="" victoria_treasure rake test
 ```
 
 ## Versioning


### PR DESCRIPTION
By changing ENTRYPOINT for CMD in a previous command, the interface of the container was broken and users had to now type the full entrypoint each time, thus making the DX worse.

Reverts: #42