### PR TITLE
[SREFTP-3791] Move to Ruby 3

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 Dockerfile
 vendor/
 .git/
+.github/

--- a/.github/workflows/release_artifact.yml
+++ b/.github/workflows/release_artifact.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Docker linting
-      run: docker run --rm -i hadolint/hadolint < Dockerfile
+      run: docker run --rm -v "$(pwd)/.hadolint.yaml:/.hadolint.yaml" -i hadolint/hadolint < Dockerfile
 
     - uses: oleksiyrudenko/gha-git-credentials@v2-latest
       with:

--- a/.github/workflows/release_artifact.yml
+++ b/.github/workflows/release_artifact.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   release:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
     - name: Docker linting

--- a/.github/workflows/test_branch.yml
+++ b/.github/workflows/test_branch.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
     - name: Docker linting

--- a/.github/workflows/test_branch.yml
+++ b/.github/workflows/test_branch.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Docker linting
-      run: docker run --rm -i hadolint/hadolint < Dockerfile
+      run: docker run --rm -v "$(pwd)/.hadolint.yaml:/.hadolint.yaml" -i hadolint/hadolint < Dockerfile
 
     - name: Unit testing
       run: |

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,4 @@
+failure-threshold: warning
+override:
+  info:
+    - DL3008

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,27 @@
-FROM gcr.io/registry-public/ruby:v3-stable
+FROM gcr.io/registry-public/ruby:v3-stable as base
 
 ENV CONTAINER_ROOT /app
 RUN mkdir -p $CONTAINER_ROOT
 WORKDIR $CONTAINER_ROOT
 
-FROM base as test
 COPY Gemfile Gemfile.lock $CONTAINER_ROOT/
-
 RUN apt-get update -y \
-    && apt-get install -y build-essential \
-    && bundle install \
+    && apt-get install -y build-essential --no-install-recommends \
+    && bundle install --without=test \
     && apt-get remove -y build-essential \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+
+FROM base as test
+RUN bundle install --with=test
+
 COPY . $CONTAINER_ROOT/
 ENTRYPOINT ["ruby", "s3secrets.rb"]
 
+
 FROM base as release
-COPY Gemfile Gemfile.lock $CONTAINER_ROOT/
-RUN bundle install --without=test
+
 COPY lib $CONTAINER_ROOT/lib
 COPY s3secrets.rb Rakefile LICENSE $CONTAINER_ROOT/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/registry-public/ruby:v2-stable as base
+FROM gcr.io/registry-public/ruby:v3-stable
 
 ENV CONTAINER_ROOT /app
 RUN mkdir -p $CONTAINER_ROOT
@@ -6,7 +6,12 @@ WORKDIR $CONTAINER_ROOT
 
 FROM base as test
 COPY Gemfile Gemfile.lock $CONTAINER_ROOT/
-RUN bundle install
+
+RUN apt update -y && \
+    apt-get install -y build-essential && \
+    bundle install && \
+    apt-get remove -y build-essential
+
 COPY . $CONTAINER_ROOT/
 ENTRYPOINT ["ruby", "s3secrets.rb"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,12 @@ WORKDIR $CONTAINER_ROOT
 FROM base as test
 COPY Gemfile Gemfile.lock $CONTAINER_ROOT/
 
-RUN apt update -y && \
-    apt-get install -y build-essential && \
-    bundle install && \
-    apt-get remove -y build-essential
+RUN apt-get update -y \
+    && apt-get install -y build-essential \
+    && bundle install \
+    && apt-get remove -y build-essential \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY . $CONTAINER_ROOT/
 ENTRYPOINT ["ruby", "s3secrets.rb"]

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'aws-sdk-s3', '~> 1'
+gem 'nokogiri'
 gem 'rake'
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,37 +2,42 @@ GEM
   remote: https://rubygems.org/
   specs:
     aws-eventstream (1.2.0)
-    aws-partitions (1.598.0)
-    aws-sdk-core (3.131.1)
+    aws-partitions (1.732.0)
+    aws-sdk-core (3.170.1)
       aws-eventstream (~> 1, >= 1.0.2)
-      aws-partitions (~> 1, >= 1.525.0)
-      aws-sigv4 (~> 1.1)
+      aws-partitions (~> 1, >= 1.651.0)
+      aws-sigv4 (~> 1.5)
       jmespath (~> 1, >= 1.6.1)
-    aws-sdk-kms (1.57.0)
-      aws-sdk-core (~> 3, >= 3.127.0)
+    aws-sdk-kms (1.63.0)
+      aws-sdk-core (~> 3, >= 3.165.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.114.0)
-      aws-sdk-core (~> 3, >= 3.127.0)
+    aws-sdk-s3 (1.119.1)
+      aws-sdk-core (~> 3, >= 3.165.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.4)
-    aws-sigv4 (1.5.0)
+    aws-sigv4 (1.5.2)
       aws-eventstream (~> 1, >= 1.0.2)
     diff-lcs (1.5.0)
-    jmespath (1.6.1)
-    rake (12.3.3)
-    rspec (3.11.0)
-      rspec-core (~> 3.11.0)
-      rspec-expectations (~> 3.11.0)
-      rspec-mocks (~> 3.11.0)
-    rspec-core (3.11.0)
-      rspec-support (~> 3.11.0)
-    rspec-expectations (3.11.0)
+    jmespath (1.6.2)
+    mini_portile2 (2.8.1)
+    nokogiri (1.14.2)
+      mini_portile2 (~> 2.8.0)
+      racc (~> 1.4)
+    racc (1.6.2)
+    rake (13.0.6)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.1)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.2)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.11.0)
-    rspec-mocks (3.11.1)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.4)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.11.0)
-    rspec-support (3.11.0)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.0)
     semver (1.0.1)
 
 PLATFORMS
@@ -40,9 +45,10 @@ PLATFORMS
 
 DEPENDENCIES
   aws-sdk-s3 (~> 1)
+  nokogiri
   rake
   rspec
   semver
 
 BUNDLED WITH
-   2.1.4
+   2.4.9

--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ docker build -t victoria_treasure --target=test .
 
 ## Running the tests
 
+
 ```bash
-docker run --entrypoint="" victoria_treasure rake test
+$ docker run --rm -ti --entrypoint="" victoria_treasure rake
 ```
 
 ## Versioning


### PR DESCRIPTION
Use v3-stable versions.

- explicitly use nokogiri 
- update testing documentation and github actions
  - move to ubuntu 22.04 runners
  - include spec folder via -v mount when running tests in actions
  - fix / silence hadolint docker warnings